### PR TITLE
Add ActiveRecord 4.2 support

### DIFF
--- a/auditor.gemspec
+++ b/auditor.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency('activerecord', '>= 3.0', '< 4.2')
+  s.add_dependency('activerecord', '>= 3.0', '< 5.0')
 
   s.add_development_dependency('rspec', '~> 2.5')
   s.add_development_dependency('sqlite3', '~> 1.3.5')

--- a/lib/auditor/recorder.rb
+++ b/lib/auditor/recorder.rb
@@ -48,7 +48,7 @@ module Auditor
     end
 
     def noop?(audit)
-      audit.action == :update && !audit.audited_changes.present?
+      audit.action.to_s == 'update' && !audit.audited_changes.present?
     end
   end
 end

--- a/lib/auditor/version.rb
+++ b/lib/auditor/version.rb
@@ -1,3 +1,3 @@
 module Auditor
-  VERSION = "2.3.4"
+  VERSION = "2.3.4.3"
 end


### PR DESCRIPTION
AR attributes will now be set as strings even if assigned a symbol.
This is tested with AR 3.2, 4.0, and 4.1 as well.
Update the gem version to 2.3.4.3 to reflect that we have made three
significant modifications since upstream.